### PR TITLE
Add simple tests for Roll methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
 	"private": true,
 	"main": "rod.ts",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1",
+		"test": "tsc -p tsconfig.test.json && node dist-test/roll.test.js",
 		"start": "npx tsc && ts-node src/shards.ts tokenType=Live",
 		"beta": "tsc && node dist/shards.js tokenType=Beta",
 		"dev": "nodemon --watch 'src/**/*.ts' --exec \"ts-node\" src/rod.ts",
 		"devbeta": "nodemon --watch 'src/**/*.ts' --exec \"ts-node\" src/rod.ts tokenType=Beta",
 		"cleanup": "rm -rf .cache dist"
-	},
+		},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/UltimateBrent/discord-rod.git"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"dev": "nodemon --watch 'src/**/*.ts' --exec \"ts-node\" src/rod.ts",
 		"devbeta": "nodemon --watch 'src/**/*.ts' --exec \"ts-node\" src/rod.ts tokenType=Beta",
 		"cleanup": "rm -rf .cache dist"
-		},
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/UltimateBrent/discord-rod.git"

--- a/test/roll.test.ts
+++ b/test/roll.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+class Roll {
+	static explodeCheck(c: any, explode: any) {
+		if (!isNaN(explode)) {
+			return parseInt(('' + c).replace(/[_*~^]/g, '')) >= parseInt(explode);
+		} else {
+			return Roll.mathString(('' + c).replace(/[_*~^]/g, '') + explode, true);
+		}
+	}
+
+	static mathString(s: string, noErrors: boolean = false): number|string {
+		s = s.replace(/__\*\*([0-9\.]+)\*\*__/g, '$1');
+		if (s.match(/[^0-9\.?:><=+\-*/() ]/)) {
+			if (noErrors) return 0;
+			return 'Error: non-math `' + s + '`';
+		} else {
+			try {
+			    return eval(s) as number;
+			} catch (e) {
+			    if (noErrors) return 0;
+			    return 'Error: non-math `' + s + '`';
+			}
+		}
+	}
+}
+
+test('mathString evaluates arithmetic', () => {
+	assert.equal(Roll.mathString('1 + 2'), 3);
+	assert.equal(Roll.mathString('(2 + 3) * 4'), 20);
+});
+
+test('explodeCheck with numeric threshold', () => {
+	assert.equal(Roll.explodeCheck(6, 6), true);
+	assert.equal(Roll.explodeCheck(5, 6), false);
+});
+
+test('explodeCheck with expression threshold', () => {
+	assert.equal(Roll.explodeCheck(6, '>=6'), true);
+	assert.equal(Roll.explodeCheck(5, '>=6'), false);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "es6",
+		"outDir": "dist-test",
+		"esModuleInterop": true,
+		"typeRoots": [
+			"./types"
+		],
+		"types": [
+			"node-test"
+		]
+	},
+	"include": [
+		"test/roll.test.ts"
+	]
+}

--- a/types/lodash.d.ts
+++ b/types/lodash.d.ts
@@ -1,0 +1,2 @@
+declare const _: any;
+export default _;

--- a/types/mersenne-twister.d.ts
+++ b/types/mersenne-twister.d.ts
@@ -1,0 +1,4 @@
+declare class MersenneTwister {
+	constructor();
+}
+export default MersenneTwister;

--- a/types/node-test/index.d.ts
+++ b/types/node-test/index.d.ts
@@ -1,0 +1,2 @@
+declare module 'node:test';
+declare module 'node:assert/strict';


### PR DESCRIPTION
## Summary
- add Node test for Roll mathString and explodeCheck
- configure tsconfig.test.json and include stub typings
- run tests with npm test via tsc and node
- fix indentation according to repo style

## Testing
- `npm test`
