### PR TITLE
Fix roll constructor filtering

### DIFF
--- a/src/lib/roll.ts
+++ b/src/lib/roll.ts
@@ -19,7 +19,7 @@ class Roll {
 		const self = this;
 
 		if (data) {
-			data = _.filter(data, function(m) { return typeof m == 'function'; }); // dont' want to pull in mongoose methods by accident
+			data = _.pickBy(data, function(m) { return typeof m != 'function'; }); // dont' want to pull in mongoose methods by accident
 			Object.assign( self, data );
 		}
 	}


### PR DESCRIPTION
## Summary
- ignore function properties when copying roll data

## Testing
- `npm test` *(fails: Error: no test specified)*