### PR TITLE
Fix tableroll iteration matching

### DIFF
--- a/src/handlers/table.handler.ts
+++ b/src/handlers/table.handler.ts
@@ -127,7 +127,7 @@ class TableHandler extends MultiCommandHandler {
 		const self = this;
 
 		// does this have iterations?
-		if (req.parts[0].match(/\[[0-9+)]\]/)) {
+		if (req.parts[0].match(/\[[0-9]+\]/)) {
 			let iterations = parseInt( req.parts.shift().replace(/[\[\]]/g, '') );
 			const name = req.parts.shift();
 			let embeds = [];


### PR DESCRIPTION
## Summary
- handle multiple digit iteration counts in `.tableroll`
- restore tab indentation

Fixes #73.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872e2bc31488329b506b3256f7e8399